### PR TITLE
Add and use ContextPath.Copy()

### DIFF
--- a/path/path.go
+++ b/path/path.go
@@ -48,6 +48,13 @@ func (c ContextPath) Append(e ...interface{}) ContextPath {
 	}
 }
 
+func (c ContextPath) Copy() ContextPath {
+	return ContextPath{
+		Path: append([]interface{}{}, c.Path...),
+		Tag:  c.Tag,
+	}
+}
+
 // Head returns the first element in the path, panics if empty.
 func (c ContextPath) Head() interface{} {
 	return c.Path[0]

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -71,7 +71,7 @@ func validate(context path.ContextPath, v reflect.Value, validateFunc CustomVali
 		}
 	}
 
-	r.Merge(validateFunc(v, context))
+	r.Merge(validateFunc(v, context.Copy()))
 
 	switch v.Kind() {
 	case reflect.Struct:


### PR DESCRIPTION
This fixes a bug where the validation runner would change a path already in a report.