### PR TITLE
*: use coreos/go-json

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/coreos/vcontext
 go 1.11
 
 require (
-	github.com/ajeddeloh/go-json v0.0.0-20170920214419-6a2fe990e083
+	github.com/coreos/go-json v0.0.0-20170920214419-6a2fe990e083
 	gopkg.in/yaml.v3 v3.0.0-20190502103701-55513cacd4ae
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/ajeddeloh/go-json v0.0.0-20170920214419-6a2fe990e083 h1:uwcvnXW76Y0rHM+qs7y8iHknWUWXYFNlD6FEVhc47TU=
-github.com/ajeddeloh/go-json v0.0.0-20170920214419-6a2fe990e083/go.mod h1:otnto4/Icqn88WCcM4bhIJNSgsh9VLBuspyyCfvof9c=
+github.com/coreos/go-json v0.0.0-20170920214419-6a2fe990e083 h1:iLYct0QOZLUuTbFBf+PDiKvpG1xPicwkcgnKaGCeTgc=
+github.com/coreos/go-json v0.0.0-20170920214419-6a2fe990e083/go.mod h1:FmxyHfvrCFfCsXRylD4QQRlQmvzl+DG6iTHyEEykPfU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20190502103701-55513cacd4ae h1:ehhBuCxzgQEGk38YjhFv/97fMIc2JGHZAhAWMmEjmu0=

--- a/json/json.go
+++ b/json/json.go
@@ -17,7 +17,7 @@ package json
 import (
 	"github.com/coreos/vcontext/tree"
 	// todo: rewrite this dep
-	json "github.com/ajeddeloh/go-json"
+	json "github.com/coreos/go-json"
 )
 
 func UnmarshalToContext(raw []byte) (tree.Node, error) {

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/coreos/vcontext/tree"
 
-	json "github.com/ajeddeloh/go-json"
+	json "github.com/coreos/go-json"
 )
 
 func TestUnmarshalToContext(t *testing.T) {


### PR DESCRIPTION
Use `coreos/go-json` instead of `ajeddeloh/go-json`.  

Before Andrew left, he created `coreos/go-json` from his repo. We should be using the CoreOS sources. 