### PR TITLE
path: preserve nil path slices in ContextPath.Copy()

### DIFF
--- a/path/path.go
+++ b/path/path.go
@@ -49,8 +49,13 @@ func (c ContextPath) Append(e ...interface{}) ContextPath {
 }
 
 func (c ContextPath) Copy() ContextPath {
+	// make sure to preserve reflect.DeepEqual() equality
+	var path []interface{}
+	if c.Path != nil {
+		path = append(path, c.Path...)
+	}
 	return ContextPath{
-		Path: append([]interface{}{}, c.Path...),
+		Path: path,
 		Tag:  c.Tag,
 	}
 }


### PR DESCRIPTION
When copying a `ContextPath` with a nil path slice, make sure the copy also has a nil slice so unit tests don't fail on `reflect.DeepEqual()` mismatches.