### PR TITLE
report: copy ContextPath when adding it to a report.Entry

### DIFF
--- a/path/path.go
+++ b/path/path.go
@@ -41,6 +41,10 @@ func (c ContextPath) String() string {
 	return strings.Join(strs, ".")
 }
 
+// Append returns a new ContextPath with the specified elements appended.
+// The underlying array is sometimes reused, so if the original path might
+// be used in future Append operations, the returned ContextPath should not
+// be stored into a long-lived data structure.  (Store a copy instead.)
 func (c ContextPath) Append(e ...interface{}) ContextPath {
 	return ContextPath{
 		Path: append(c.Path, e...),
@@ -48,6 +52,11 @@ func (c ContextPath) Append(e ...interface{}) ContextPath {
 	}
 }
 
+// Copy returns an identical ContextPath that shares no state with the
+// original.  When storing a ContextPath into a data structure, usually a
+// copy should be stored instead of the original (for example, Report does
+// this), since Append sometimes modifies the path's underlying array in
+// place.
 func (c ContextPath) Copy() ContextPath {
 	// make sure to preserve reflect.DeepEqual() equality
 	var path []interface{}

--- a/report/report.go
+++ b/report/report.go
@@ -131,7 +131,7 @@ func (r *Report) AddOn(c path.ContextPath, err error, k EntryKind) {
 	}
 	r.Entries = append(r.Entries, Entry{
 		Message: err.Error(),
-		Context: c,
+		Context: c.Copy(),
 		Kind:    k,
 	})
 }

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -71,7 +71,7 @@ func validate(context path.ContextPath, v reflect.Value, validateFunc CustomVali
 		}
 	}
 
-	r.Merge(validateFunc(v, context.Copy()))
+	r.Merge(validateFunc(v, context))
 
 	switch v.Kind() {
 	case reflect.Struct:


### PR DESCRIPTION
`ContextPath.Append()` makes a new `ContextPath` struct and path slice, but the slice sometimes refers to the original underlying array, depending what `append()` decides to do.  As a result, anything wanting to persist a path outside the current call chain needs to make a `Copy()` and persist that.  Otherwise the following pattern would be unsafe:

    r.AddOnError(c.Append("mode"), validateMode(f.Mode))
    r.AddOnError(c.Append("overwrite"), f.validateOverwrite())

`Report` was failing to do this, and it seemed fine on amd64, but on 386 it caused one Butane test to fail.  Fix `Report` to copy paths.  Ignition `merge.Transcript` and Butane `translate.TranslationSet` already do this.

Alternatively, we could make `Append()` always copy the path slice.  But there are a lot of call sites which build paths and then throw them away, and very few places that actually persist paths, so it seems feasible and more efficient to retain the current `Append()` behavior for now.